### PR TITLE
Configure CORS

### DIFF
--- a/src/KanbanBoard.WebApi/Configurations/ApplicationCorsOptions.cs
+++ b/src/KanbanBoard.WebApi/Configurations/ApplicationCorsOptions.cs
@@ -1,0 +1,9 @@
+namespace KanbanBoard.WebApi.Configurations
+{
+    public class ApplicationCorsOptions
+    {
+        public string PolicyName { get; set; }
+        public string AllowedOrigin { get; set; }
+
+    }
+}

--- a/src/KanbanBoard.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/KanbanBoard.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,30 @@
+using KanbanBoard.WebApi.Configurations;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace KanbanBoard.WebApi.Extensions
 {
     public static class ServiceCollectionExtensions
     {
-
+        public static IServiceCollection AddApplicationCorsPolicy(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            var corsOptions = new ApplicationCorsOptions();
+            configuration.Bind("CorsOptions", corsOptions);
+            return services
+                .Configure<ApplicationCorsOptions>(configuration.GetSection("CorsOptions"))
+                .AddCors(options =>
+                {
+                    options.AddPolicy(corsOptions.PolicyName, configurePolicy =>
+                    {
+                        configurePolicy
+                            .AllowCredentials()
+                            .AllowAnyHeader()
+                            .AllowAnyMethod()
+                            .WithOrigins(corsOptions.AllowedOrigin);
+                    });
+                });
+        }
     }
 }

--- a/src/KanbanBoard.WebApi/Startup.cs
+++ b/src/KanbanBoard.WebApi/Startup.cs
@@ -1,8 +1,10 @@
+using KanbanBoard.WebApi.Configurations;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace KanbanBoard.WebApi
 {
@@ -34,6 +36,10 @@ namespace KanbanBoard.WebApi
             });
 
             app.UseRouting();
+
+            ApplicationCorsOptions corsOptions = app.ApplicationServices
+                .GetService<IOptions<ApplicationCorsOptions>>().Value;
+            app.UseCors(corsOptions.PolicyName);
 
             app.UseAuthorization();
 


### PR DESCRIPTION
add CORS configuration to allow requests only from a specific origin provided in the app settings

### Description of changes

### Issues resolved

- Fixes #26 

### Checklist

- [ ] Tests are passing
- [ ] Docs are updated
